### PR TITLE
VPC Cross-region subnet: fix project_id argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
 	github.com/mattn/go-isatty v0.0.6 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/selectel/go-selvpcclient v1.7.0
+	github.com/selectel/go-selvpcclient v1.8.1
 	github.com/stretchr/testify v1.3.0
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -304,8 +304,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/selectel/go-selvpcclient v1.7.0 h1:LG7hAJIHlyTAAcJHfnAmqZwz6MOmWATBibYnLqU0HDo=
-github.com/selectel/go-selvpcclient v1.7.0/go.mod h1:JQfYjuRMsdeifXPfkEJO6GuEtUo8jWQRHXpwiOIKu4A=
+github.com/selectel/go-selvpcclient v1.8.1 h1:UpTk8/vLZWte/SBDoTabRSynEfOWzPacT3o7OvvBFO0=
+github.com/selectel/go-selvpcclient v1.8.1/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=

--- a/selectel/resource_selectel_vpc_crossregion_subnet_v2.go
+++ b/selectel/resource_selectel_vpc_crossregion_subnet_v2.go
@@ -168,6 +168,7 @@ func resourceVPCCrossRegionSubnetV2Read(d *schema.ResourceData, meta interface{}
 	d.Set("cidr", crossRegionSubnet.CIDR)
 	d.Set("status", crossRegionSubnet.Status)
 	d.Set("vlan_id", crossRegionSubnet.VLANID)
+	d.Set("project_id", crossRegionSubnet.ProjectID)
 
 	associatedServers := serversMapsFromStructs(crossRegionSubnet.Servers)
 	if err := d.Set("servers", associatedServers); err != nil {
@@ -182,14 +183,6 @@ func resourceVPCCrossRegionSubnetV2Read(d *schema.ResourceData, meta interface{}
 	associatedRegions := regionsMapsFromSubnetsStructs(crossRegionSubnet.Subnets)
 	if err := d.Set("regions", associatedRegions); err != nil {
 		log.Print(errSettingComplexAttr("regions", err))
-	}
-
-	associatedProjectID, err := projectIDFromSubnetsMaps(associatedSubnets)
-	if err != nil {
-		log.Print(errParseCrossRegionSubnetV2ProjectID(err))
-	}
-	if err := d.Set("project_id", associatedProjectID); err != nil {
-		log.Print(errSettingComplexAttr("project_id", err))
 	}
 
 	return nil

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/crossregionsubnets/schemas.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/crossregionsubnets/schemas.go
@@ -19,6 +19,9 @@ type CrossRegionSubnet struct {
 	// Status shows if cross-region subnet is used.
 	Status string `json:"status"`
 
+	// ProjectID represents an associated Identity service project.
+	ProjectID string `json:"project_id"`
+
 	// Servers contains info about servers to which cross-region subnet is associated to.
 	Servers []servers.Server `json:"servers"`
 

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// AppVersion is a version of the application.
-	AppVersion = "1.7.0"
+	AppVersion = "1.8.1"
 
 	// AppName is a global application name.
 	AppName = "go-selvpcclient"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,7 +208,7 @@ github.com/posener/complete
 github.com/posener/complete/cmd/install
 github.com/posener/complete/cmd
 github.com/posener/complete/match
-# github.com/selectel/go-selvpcclient v1.7.0
+# github.com/selectel/go-selvpcclient v1.8.1
 github.com/selectel/go-selvpcclient/selvpcclient
 github.com/selectel/go-selvpcclient/selvpcclient/resell
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2


### PR DESCRIPTION
Use go-selvpcclient v1.8.1.

Don't read project_id from the first associated subnet but use parent cross_region_subnet value.

For #52 