### PR TITLE
Changelog: fix links to repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,60 +3,60 @@
 
 BUG FIXES:
 
-* Fixed an issue with empty `project_id` argument of the `selectel_vpc_crossregion_subnet_v2` resource ([#52](https://github.com/terraform-providers/terraform-provider-aws/issues/52))
+* Fixed an issue with empty `project_id` argument of the `selectel_vpc_crossregion_subnet_v2` resource ([#52](https://github.com/terraform-providers/terraform-provider-selectel/issues/52))
 
 IMPROVEMENTS:
 
-* Migrated to Go Modules ([#47](https://github.com/terraform-providers/terraform-provider-aws/issues/47))
-* Updated Terraform SDK to `v1.12.0-beta1` ([#51](https://github.com/terraform-providers/terraform-provider-aws/issues/51))
-* Updated `golangci-lint` in CI to `v1.15.0` ([#54](https://github.com/terraform-providers/terraform-provider-aws/issues/54))
+* Migrated to Go Modules ([#47](https://github.com/terraform-providers/terraform-provider-selectel/issues/47))
+* Updated Terraform SDK to `v1.12.0-beta1` ([#51](https://github.com/terraform-providers/terraform-provider-selectel/issues/51))
+* Updated `golangci-lint` in CI to `v1.15.0` ([#54](https://github.com/terraform-providers/terraform-provider-selectel/issues/54))
 
 ## 2.0.0 (February 04, 2019)
 
 BREAKING CHANGES:
 
-* All `selvpc_resell_*` resources were renamed to `selectel_vpc_*` resources ([#45](https://github.com/terraform-providers/terraform-provider-aws/issues/45))
+* All `selvpc_resell_*` resources were renamed to `selectel_vpc_*` resources ([#45](https://github.com/terraform-providers/terraform-provider-selectel/issues/45))
 
 FEATURES:
 
-* __New Resource:__ `selectel_vpc_crossregion_subnet_v2` ([#43](https://github.com/terraform-providers/terraform-provider-aws/issues/43))
+* __New Resource:__ `selectel_vpc_crossregion_subnet_v2` ([#43](https://github.com/terraform-providers/terraform-provider-selectel/issues/43))
 
 BUG FIXES:
 
-* Fixed VPC V2 Token Account acceptance test ([#41](https://github.com/terraform-providers/terraform-provider-aws/issues/41))
+* Fixed VPC V2 Token Account acceptance test ([#41](https://github.com/terraform-providers/terraform-provider-selectel/issues/41))
 
 ## 1.1.0 (January 08, 2019)
 
 FEATURES:
 
-* __New Resource:__ `selvpc_resell_keypair_v2` ([#29](https://github.com/terraform-providers/terraform-provider-aws/issues/29))
-* __New Resource:__ `selvpc_resell_vrrp_subnet_v2` ([#35](https://github.com/terraform-providers/terraform-provider-aws/issues/35))
+* __New Resource:__ `selvpc_resell_keypair_v2` ([#29](https://github.com/terraform-providers/terraform-provider-selectel/issues/29))
+* __New Resource:__ `selvpc_resell_vrrp_subnet_v2` ([#35](https://github.com/terraform-providers/terraform-provider-selectel/issues/35))
 
 IMPROVEMENTS:
 
-* Added tuned HTTP client to prevent errors when making call to the Resell API ([#30](https://github.com/terraform-providers/terraform-provider-aws/issues/30))
-* Added the same format for all debug messages ([#32](https://github.com/terraform-providers/terraform-provider-aws/issues/32))
-* Remove the `type` argument of the `selvpc_resell_subnet_v2` from the documentation as it doesn't exist ([#36](https://github.com/terraform-providers/terraform-provider-aws/issues/36))
-* Updated Go-selvpcclient dependency to `v1.6.0` ([#33](https://github.com/terraform-providers/terraform-provider-aws/issues/33))
-* Used `v1.11.x` Go version in Travis CI ([#40](https://github.com/terraform-providers/terraform-provider-aws/issues/40))
-* Updated GolangCI-Lint in Travis CI to `v1.12.5` ([#37](https://github.com/terraform-providers/terraform-provider-aws/issues/37))
+* Added tuned HTTP client to prevent errors when making call to the Resell API ([#30](https://github.com/terraform-providers/terraform-provider-selectel/issues/30))
+* Added the same format for all debug messages ([#32](https://github.com/terraform-providers/terraform-provider-selectel/issues/32))
+* Remove the `type` argument of the `selvpc_resell_subnet_v2` from the documentation as it doesn't exist ([#36](https://github.com/terraform-providers/terraform-provider-selectel/issues/36))
+* Updated Go-selvpcclient dependency to `v1.6.0` ([#33](https://github.com/terraform-providers/terraform-provider-selectel/issues/33))
+* Used `v1.11.x` Go version in Travis CI ([#40](https://github.com/terraform-providers/terraform-provider-selectel/issues/40))
+* Updated GolangCI-Lint in Travis CI to `v1.12.5` ([#37](https://github.com/terraform-providers/terraform-provider-selectel/issues/37))
 
 ## 1.0.0 (December 19, 2018)
 
 FEATURES:
 
-* __New Resource:__ `selvpc_resell_role_v2` ([#4](https://github.com/terraform-providers/terraform-provider-aws/issues/4))
-* __New Resource:__ `selvpc_resell_subnet_v2` ([#1](https://github.com/terraform-providers/terraform-provider-aws/issues/1))
-* __New Resource:__ `selvpc_resell_token_v2` ([#2](https://github.com/terraform-providers/terraform-provider-aws/issues/2))
-* __New Resource:__ `selvpc_resell_user_v2` ([#3](https://github.com/terraform-providers/terraform-provider-aws/issues/3))
+* __New Resource:__ `selvpc_resell_role_v2` ([#4](https://github.com/terraform-providers/terraform-provider-selectel/issues/4))
+* __New Resource:__ `selvpc_resell_subnet_v2` ([#1](https://github.com/terraform-providers/terraform-provider-selectel/issues/1))
+* __New Resource:__ `selvpc_resell_token_v2` ([#2](https://github.com/terraform-providers/terraform-provider-selectel/issues/2))
+* __New Resource:__ `selvpc_resell_user_v2` ([#3](https://github.com/terraform-providers/terraform-provider-selectel/issues/3))
 
 IMPROVEMENTS:
 
-* Updated `Building The Provider` and `Using the provider` sections in the Readme ([#6](https://github.com/terraform-providers/terraform-provider-aws/issues/6))
-* Added `GolangCI-Lint` in the `TravisCI`, removed separated linters scripts and cleaned up `GNUmakefile` ([#12](https://github.com/terraform-providers/terraform-provider-aws/issues/12))
-* Added more context into error messages ([#17](https://github.com/terraform-providers/terraform-provider-aws/issues/17))
-* Added tuned HTTP timeouts instead of the default ones from Go's `net/http` package ([#14](https://github.com/terraform-providers/terraform-provider-aws/issues/14))
-* Updated `go-selvpcclient` dependency to `v1.5.0` ([#14](https://github.com/terraform-providers/terraform-provider-aws/issues/14))
+* Updated `Building The Provider` and `Using the provider` sections in the Readme ([#6](https://github.com/terraform-providers/terraform-provider-selectel/issues/6))
+* Added `GolangCI-Lint` in the `TravisCI`, removed separated linters scripts and cleaned up `GNUmakefile` ([#12](https://github.com/terraform-providers/terraform-provider-selectel/issues/12))
+* Added more context into error messages ([#17](https://github.com/terraform-providers/terraform-provider-selectel/issues/17))
+* Added tuned HTTP timeouts instead of the default ones from Go's `net/http` package ([#14](https://github.com/terraform-providers/terraform-provider-selectel/issues/14))
+* Updated `go-selvpcclient` dependency to `v1.5.0` ([#14](https://github.com/terraform-providers/terraform-provider-selectel/issues/14))
 
 ## 0.3.0 (November 26, 2018)
 


### PR DESCRIPTION
Set links to terraform-provider-selectel instead of
terraform-provider-aws.