### PR TITLE
Update Go, Terraform and GolangCI-Lint versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - GOFLAGS=-mod=vendor GO111MODULE=on
 
 install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.16.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - "1.11.x"
+  - "1.12.x"
 services:
   - "docker"
 env:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This provider plugin is maintained by:
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
+-	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -	[Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
 Building The Provider

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.11.x
--	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.12 (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -47,7 +47,7 @@ Also there are lots of examples in the [selectel/terraform-examples](https://git
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Go version: use 1.12.x in docs and CI

Use Go 1.12.x version for CI tests and in README.md.

Readme: use Terraform v0.12.x in docs

Update Terraform version in docs.

CI: use golangci-lint v1.17.1 in tests

Use newer version of golangci-lint.