### PR TITLE
MKS V1: use default Kubernetes version in tests

### DIFF
--- a/selectel/import_selectel_mks_cluster_v1_test.go
+++ b/selectel/import_selectel_mks_cluster_v1_test.go
@@ -11,7 +11,7 @@ func TestAccMKSClusterV1ImportBasic(t *testing.T) {
 	resourceName := "selectel_mks_cluster_v1.cluster_tf_acc_test_1"
 	projectName := acctest.RandomWithPrefix("tf-acc")
 	clusterName := acctest.RandomWithPrefix("tf-acc-cl")
-	kubeVersion := "1.16.8"
+	kubeVersion := testAccMKSClusterV1GetDefaultKubeVersion(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccSelectelPreCheck(t) },

--- a/selectel/import_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/import_selectel_mks_nodegroup_v1_test.go
@@ -11,7 +11,7 @@ func TestAccMKSNodegroupV1ImportBasic(t *testing.T) {
 	resourceName := "selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1"
 	projectName := acctest.RandomWithPrefix("tf-acc")
 	clusterName := acctest.RandomWithPrefix("tf-acc-cl")
-	kubeVersion := "1.15.11"
+	kubeVersion := testAccMKSClusterV1GetDefaultKubeVersion(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccSelectelPreCheck(t) },

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -23,7 +23,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 
 	projectName := acctest.RandomWithPrefix("tf-acc")
 	clusterName := acctest.RandomWithPrefix("tf-acc-cl")
-	kubeVersion := "1.15.11"
+	kubeVersion := testAccMKSClusterV1GetDefaultKubeVersion(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccSelectelPreCheck(t) },


### PR DESCRIPTION
Implement "testAccMKSClusterV1GetDefaultKubeVersion" that allows
to get the default Kubernetes version from the MKS API and use it in
acceptance tests.
Update all MKS acceptance tests.

For #74 