### PR TITLE
Domains V1: add domain resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
-	github.com/selectel/domains-go v0.1.0
+	github.com/selectel/domains-go v0.2.0
 	github.com/selectel/go-selvpcclient v1.11.0
 	github.com/selectel/mks-go v0.2.0
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
+	github.com/selectel/domains-go v0.1.0
 	github.com/selectel/go-selvpcclient v1.11.0
 	github.com/selectel/mks-go v0.2.0
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/selectel/domains-go v0.1.0 h1:Je7Q5YfTevGsyRiVMBcXqXJZnffN24JZVAZRPnhK4nk=
+github.com/selectel/domains-go v0.1.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
 github.com/selectel/go-selvpcclient v1.11.0 h1:M3p6LpTHe3AnQlQ+qIup3XLclztFcX5cSsLDmopK+X8=
 github.com/selectel/go-selvpcclient v1.11.0/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
 github.com/selectel/mks-go v0.2.0 h1:DyAbcjM03bO6Jq7J7apX+engY4GVZP1RHMkSfrzHFnc=

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/selectel/domains-go v0.1.0 h1:Je7Q5YfTevGsyRiVMBcXqXJZnffN24JZVAZRPnhK4nk=
 github.com/selectel/domains-go v0.1.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
+github.com/selectel/domains-go v0.2.0 h1:UBm6tc45sXsziqG7MirfHxaoMf3yYpFb2vx3GygU4kI=
+github.com/selectel/domains-go v0.2.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
 github.com/selectel/go-selvpcclient v1.11.0 h1:M3p6LpTHe3AnQlQ+qIup3XLclztFcX5cSsLDmopK+X8=
 github.com/selectel/go-selvpcclient v1.11.0/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
 github.com/selectel/mks-go v0.2.0 h1:DyAbcjM03bO6Jq7J7apX+engY4GVZP1RHMkSfrzHFnc=

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"strings"
 
+	domainsV1 "github.com/selectel/domains-go/pkg/v1"
 	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
-	v2 "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2"
+	resellV2 "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2"
 )
 
 // Config contains all available configuration options.
@@ -23,7 +24,7 @@ func (c *Config) Validate() error {
 		return errors.New("token must be specified")
 	}
 	if c.Endpoint == "" {
-		c.Endpoint = strings.Join([]string{resell.Endpoint, v2.APIVersion}, "/")
+		c.Endpoint = strings.Join([]string{resell.Endpoint, resellV2.APIVersion}, "/")
 	}
 	if c.Region != "" {
 		if err := validateRegion(c.Region); err != nil {
@@ -34,5 +35,9 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
-	return v2.NewV2ResellClientWithEndpoint(c.Token, c.Endpoint)
+	return resellV2.NewV2ResellClientWithEndpoint(c.Token, c.Endpoint)
+}
+
+func (c *Config) domainsV1Client() *domainsV1.ServiceClient {
+	return domainsV1.NewDomainsClientV1WithDefaultEndpoint(c.Token)
 }

--- a/selectel/errors.go
+++ b/selectel/errors.go
@@ -30,6 +30,10 @@ func errParseMKSNodegroupV1ID(nodegroupID string) error {
 	return fmt.Errorf("got error parsing nodegroup ID: %s", nodegroupID)
 }
 
+func errParseDomainsDomainV1ID(domainID string) error {
+	return fmt.Errorf("got error parsing domain ID: %s", domainID)
+}
+
 func errSearchingProjectRole(projectID string, err error) error {
 	return fmt.Errorf("can't find role for project '%s': %s", projectID, err)
 }

--- a/selectel/errors_test.go
+++ b/selectel/errors_test.go
@@ -2,6 +2,7 @@ package selectel
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -148,6 +149,16 @@ func TestErrResourceDeprecated(t *testing.T) {
 	expected := errors.New("some_vpc_object resource has been deprecated")
 
 	actual := errResourceDeprecated(resource)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestErrParseDomainsDomainV1ID(t *testing.T) {
+	domainID := "badid"
+
+	expected := fmt.Errorf("got error parsing domain ID: %s", domainID)
+
+	actual := errParseDomainsDomainV1ID(domainID)
 
 	assert.Equal(t, expected, actual)
 }

--- a/selectel/import_selectel_domains_domain_v1_test.go
+++ b/selectel/import_selectel_domains_domain_v1_test.go
@@ -1,0 +1,30 @@
+package selectel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDomainsDomainV1ImportBasic(t *testing.T) {
+	resourceName := "selectel_domains_domain_v1.domain_tf_acc_test_1"
+	testDomainName := fmt.Sprintf("%s.xyz", acctest.RandomWithPrefix("tf-acc"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccSelectelPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDomainsV1DomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainsDomainV1Basic(testDomainName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -19,6 +19,7 @@ const (
 	objectVRRPSubnet    = "VRRP subnet"
 	objectCluster       = "cluster"
 	objectNodegroup     = "nodegroup"
+	objectDomain        = "domain"
 )
 
 // This is a global MutexKV for use within this plugin.
@@ -66,6 +67,7 @@ func Provider() terraform.ResourceProvider {
 			"selectel_vpc_crossregion_subnet_v2": resourceVPCCrossRegionSubnetV2(),
 			"selectel_mks_cluster_v1":            resourceMKSClusterV1(),
 			"selectel_mks_nodegroup_v1":          resourceMKSNodegroupV1(),
+			"selectel_domains_domain_v1":         resourceDomainsDomainV1(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -8,11 +8,8 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	v1 "github.com/selectel/domains-go/pkg/v1"
 	"github.com/selectel/domains-go/pkg/v1/domain"
 )
-
-const domainsEndpoint = "https://api.selectel.ru/domains/v1"
 
 func resourceDomainsDomainV1() *schema.Resource {
 	return &schema.Resource{
@@ -48,7 +45,7 @@ func resourceDomainsDomainV1() *schema.Resource {
 func resourceDomainsDomainV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	ctx := context.Background()
-	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+	client := config.domainsV1Client()
 
 	createOpts := &domain.CreateOpts{
 		Name: d.Get("name").(string),
@@ -68,7 +65,7 @@ func resourceDomainsDomainV1Create(d *schema.ResourceData, meta interface{}) err
 func resourceDomainsDomainV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	ctx := context.Background()
-	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+	client := config.domainsV1Client()
 
 	log.Print(msgGet(objectDomain, d.Id()))
 
@@ -101,7 +98,7 @@ func resourceDomainsDomainV1Update(d *schema.ResourceData, meta interface{}) err
 func resourceDomainsDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	ctx := context.Background()
-	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+	client := config.domainsV1Client()
 
 	log.Print(msgDelete(objectDomain, d.Id()))
 

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -15,7 +15,6 @@ func resourceDomainsDomainV1() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDomainsDomainV1Create,
 		Read:   resourceDomainsDomainV1Read,
-		Update: resourceDomainsDomainV1Update,
 		Delete: resourceDomainsDomainV1Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -89,10 +88,6 @@ func resourceDomainsDomainV1Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("user_id", domainObj.UserID)
 
 	return nil
-}
-
-func resourceDomainsDomainV1Update(d *schema.ResourceData, meta interface{}) error {
-	return resourceDomainsDomainV1Read(d, meta)
 }
 
 func resourceDomainsDomainV1Delete(d *schema.ResourceData, meta interface{}) error {

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -27,6 +27,19 @@ func resourceDomainsDomainV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+			},
+			"create_date": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"change_date": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 		},
 	}

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -24,14 +24,6 @@ func resourceDomainsDomainV1() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"create_date": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"change_date": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"user_id": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -82,8 +74,6 @@ func resourceDomainsDomainV1Read(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Set("name", domainObj.Name)
-	d.Set("create_date", domainObj.CreateDate)
-	d.Set("change_date", domainObj.ChangeDate)
 	d.Set("user_id", domainObj.UserID)
 
 	return nil

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -2,7 +2,6 @@ package selectel
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -70,7 +69,7 @@ func resourceDomainsDomainV1Read(d *schema.ResourceData, meta interface{}) error
 
 	domainID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("failed to parse domain ID: %w", err)
+		return errParseDomainsDomainV1ID(d.Id())
 	}
 
 	domainObj, resp, err := domain.GetByID(ctx, client, domainID)
@@ -99,7 +98,7 @@ func resourceDomainsDomainV1Delete(d *schema.ResourceData, meta interface{}) err
 
 	domainID, err := strconv.Atoi(d.Id())
 	if err != nil {
-		return fmt.Errorf("failed to parse domain ID: %w", err)
+		return errParseDomainsDomainV1ID(d.Id())
 	}
 
 	_, err = domain.Delete(ctx, client, domainID)

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -1,0 +1,106 @@
+package selectel
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	v1 "github.com/selectel/domains-go/pkg/v1"
+	"github.com/selectel/domains-go/pkg/v1/domain"
+)
+
+const domainsEndpoint = "https://api.selectel.ru/domains/v1"
+
+func resourceDomainsDomainV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDomainsDomainV1Create,
+		Read:   resourceDomainsDomainV1Read,
+		Update: resourceDomainsDomainV1Update,
+		Delete: resourceDomainsDomainV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceDomainsDomainV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+
+	createOpts := &domain.CreateOpts{
+		Name: d.Get("name").(string),
+	}
+
+	log.Print(msgCreate(objectDomain, createOpts))
+	domainObj, _, err := domain.Create(ctx, client, createOpts)
+	if err != nil {
+		return errCreatingObject(objectDomain, err)
+	}
+
+	d.SetId(strconv.Itoa(domainObj.ID))
+
+	return resourceDomainsDomainV1Read(d, meta)
+}
+
+func resourceDomainsDomainV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+
+	log.Print(msgGet(objectDomain, d.Id()))
+
+	domainID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to parse domain ID: %w", err)
+	}
+
+	domainObj, resp, err := domain.GetByID(ctx, client, domainID)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+		return errGettingObject(objectDomain, d.Id(), err)
+	}
+
+	d.Set("name", domainObj.Name)
+	d.Set("create_date", domainObj.CreateDate)
+	d.Set("change_date", domainObj.ChangeDate)
+	d.Set("user_id", domainObj.UserID)
+
+	return nil
+}
+
+func resourceDomainsDomainV1Update(d *schema.ResourceData, meta interface{}) error {
+	return resourceDomainsDomainV1Read(d, meta)
+}
+
+func resourceDomainsDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+	client := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+
+	log.Print(msgDelete(objectDomain, d.Id()))
+
+	domainID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to parse domain ID: %w", err)
+	}
+
+	_, err = domain.Delete(ctx, client, domainID)
+	if err != nil {
+		return errDeletingObject(objectDomain, d.Id(), err)
+	}
+
+	return nil
+}

--- a/selectel/resource_selectel_domains_domain_v1_test.go
+++ b/selectel/resource_selectel_domains_domain_v1_test.go
@@ -61,7 +61,7 @@ func testAccCheckDomainsDomainV1Exists(n string, selectelDomain *domain.View) re
 
 		domainID, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("failed to parse domain ID: %w", err)
+			return errParseDomainsDomainV1ID(rs.Primary.ID)
 		}
 
 		foundDomain, _, err := domain.GetByID(ctx, domainsClientV1, domainID)
@@ -87,7 +87,7 @@ func testAccCheckDomainsV1DomainDestroy(s *terraform.State) error {
 
 		domainID, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("failed to parse domain ID: %w", err)
+			return errParseDomainsDomainV1ID(rs.Primary.ID)
 		}
 
 		_, _, err = domain.GetByID(ctx, domainsClientV1, domainID)

--- a/selectel/resource_selectel_domains_domain_v1_test.go
+++ b/selectel/resource_selectel_domains_domain_v1_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	v1 "github.com/selectel/domains-go/pkg/v1"
 	"github.com/selectel/domains-go/pkg/v1/domain"
 )
 
@@ -58,7 +57,7 @@ func testAccCheckDomainsDomainV1Exists(n string, selectelDomain *domain.View) re
 		config := testAccProvider.Meta().(*Config)
 		ctx := context.Background()
 
-		domainsClientV1 := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+		domainsClientV1 := config.domainsV1Client()
 
 		domainID, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
@@ -78,7 +77,7 @@ func testAccCheckDomainsDomainV1Exists(n string, selectelDomain *domain.View) re
 
 func testAccCheckDomainsV1DomainDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	domainsClientV1 := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+	domainsClientV1 := config.domainsV1Client()
 	ctx := context.Background()
 
 	for _, rs := range s.RootModule().Resources {

--- a/selectel/resource_selectel_domains_domain_v1_test.go
+++ b/selectel/resource_selectel_domains_domain_v1_test.go
@@ -1,0 +1,101 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	v1 "github.com/selectel/domains-go/pkg/v1"
+	"github.com/selectel/domains-go/pkg/v1/domain"
+)
+
+func TestAccDomainsDomainV1Basic(t *testing.T) {
+	var testDomain domain.View
+
+	testDomainName := fmt.Sprintf("%s.xyz", acctest.RandomWithPrefix("tf-acc"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccSelectelPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDomainsV1DomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainsDomainV1Basic(testDomainName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainsDomainV1Exists("selectel_domains_domain_v1.domain_tf_acc_test_1",
+						&testDomain),
+					resource.TestCheckResourceAttr("selectel_domains_domain_v1.domain_tf_acc_test_1",
+						"name", testDomainName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainsDomainV1Basic(domainName string) string {
+	return fmt.Sprintf(`
+resource "selectel_domains_domain_v1" "domain_tf_acc_test_1" {
+  name = "%s"
+}`, domainName)
+}
+
+func testAccCheckDomainsDomainV1Exists(n string, selectelDomain *domain.View) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("no ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		ctx := context.Background()
+
+		domainsClientV1 := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+
+		domainID, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to parse domain ID: %w", err)
+		}
+
+		foundDomain, _, err := domain.GetByID(ctx, domainsClientV1, domainID)
+		if err != nil {
+			return err
+		}
+
+		*selectelDomain = *foundDomain
+
+		return nil
+	}
+}
+
+func testAccCheckDomainsV1DomainDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	domainsClientV1 := v1.NewDomainsClientV1(config.Token, domainsEndpoint)
+	ctx := context.Background()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "selectel_domains_domain_v1" {
+			continue
+		}
+
+		domainID, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("failed to parse domain ID: %w", err)
+		}
+
+		_, _, err = domain.GetByID(ctx, domainsClientV1, domainID)
+		if err == nil {
+			return errors.New("domain still exists")
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/selectel/domains-go/LICENSE
+++ b/vendor/github.com/selectel/domains-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/selectel/domains-go/pkg/v1/client.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/client.go
@@ -1,0 +1,223 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// appName represents an application name.
+	appName = "domains-go"
+
+	// appVersion is a version of the application.
+	appVersion = "0.1.0"
+
+	// userAgent contains a basic user agent that will be used in queries.
+	userAgent = appName + "/" + appVersion
+
+	// defaultHTTPTimeout represents the default timeout (in seconds) for HTTP requests.
+	defaultHTTPTimeout = 120
+
+	// defaultDialTimeout represents the default timeout (in seconds) for HTTP connection establishments.
+	defaultDialTimeout = 60
+
+	// defaultKeepaliveTimeout represents the default keep-alive period for an active network connection.
+	defaultKeepaliveTimeout = 60
+
+	// defaultMaxIdleConns represents the maximum number of idle (keep-alive) connections.
+	defaultMaxIdleConns = 100
+
+	// defaultIdleConnTimeout represents the maximum amount of time an idle (keep-alive) connection will remain
+	// idle before closing itself.
+	defaultIdleConnTimeout = 100
+
+	// defaultTLSHandshakeTimeout represents the default timeout (in seconds) for TLS handshake.
+	defaultTLSHandshakeTimeout = 60
+
+	// defaultExpectContinueTimeout represents the default amount of time to wait for a server's first
+	// response headers.
+	defaultExpectContinueTimeout = 1
+)
+
+const RecordsEndpoint = "records"
+
+// ServiceClient stores details that are needed to work with Selectel Domains API.
+type ServiceClient struct {
+	// HTTPClient represents an initialized HTTP client that will be used to do requests.
+	HTTPClient *http.Client
+
+	// Token is a client authentication token.
+	Token string
+
+	// Endpoint represents an endpoint that will be used in all requests.
+	Endpoint string
+
+	// UserAgent contains user agent that will be used in all requests.
+	UserAgent string
+}
+
+// NewDomainsClientV1 initializes a new client for the Domains API V1.
+func NewDomainsClientV1(token, endpoint string) *ServiceClient {
+	return &ServiceClient{
+		HTTPClient: newHTTPClient(),
+		Token:      token,
+		Endpoint:   endpoint,
+		UserAgent:  userAgent,
+	}
+}
+
+// NewDomainsClientV1WithCustomHTTP initializes a new client for the Domains API V1
+// using custom HTTP client.
+// If customHTTPClient is nil - default HTTP client will be used.
+func NewDomainsClientV1WithCustomHTTP(customHTTPClient *http.Client, token, endpoint string) *ServiceClient {
+	if customHTTPClient == nil {
+		customHTTPClient = newHTTPClient()
+	}
+	return &ServiceClient{
+		HTTPClient: customHTTPClient,
+		Token:      token,
+		Endpoint:   endpoint,
+		UserAgent:  userAgent,
+	}
+}
+
+// newHTTPClient returns a reference to an initialized and configured HTTP client.
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   defaultHTTPTimeout * time.Second,
+		Transport: newHTTPTransport(),
+	}
+}
+
+// newHTTPTransport returns a reference to an initialized and configured HTTP transport.
+func newHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   defaultDialTimeout * time.Second,
+			KeepAlive: defaultKeepaliveTimeout * time.Second,
+		}).DialContext,
+		MaxIdleConns:          defaultMaxIdleConns,
+		IdleConnTimeout:       defaultIdleConnTimeout * time.Second,
+		TLSHandshakeTimeout:   defaultTLSHandshakeTimeout * time.Second,
+		ExpectContinueTimeout: defaultExpectContinueTimeout * time.Second,
+	}
+}
+
+// DoRequest performs the HTTP request with the current ServiceClient's HTTPClient.
+// Authentication and optional headers will be added automatically.
+func (client *ServiceClient) DoRequest(ctx context.Context, method, path string, body io.Reader) (*ResponseResult, error) {
+	// Prepare an HTTP request with the provided context.
+	request, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	request.Header.Set("User-Agent", client.UserAgent)
+	request.Header.Set("X-Token", client.Token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request = request.WithContext(ctx)
+
+	// Send the HTTP request and populate the ResponseResult.
+	response, err := client.HTTPClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	responseResult := &ResponseResult{
+		Response: response,
+	}
+
+	// Check status code and populate custom error body with extended error message if it's possible.
+	if response.StatusCode >= http.StatusBadRequest {
+		err = responseResult.extractErr()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return responseResult, nil
+}
+
+// ResponseResult represents a result of an HTTP request.
+// It embeds standard http.Response and adds custom API error representations.
+type ResponseResult struct {
+	*http.Response
+
+	*ErrNotFound
+
+	*ErrGeneric
+
+	// Err contains an error that can be provided to a caller.
+	Err error
+}
+
+// ErrNotFound represents 404 status code error of an HTTP response.
+type ErrNotFound struct {
+	Error string `json:"error"`
+}
+
+// ErrGeneric represents a generic error of an HTTP response.
+type ErrGeneric struct {
+	Error string `json:"error"`
+}
+
+// ExtractResult allows to provide an object into which ResponseResult body will be extracted.
+func (result *ResponseResult) ExtractResult(to interface{}) error {
+	body, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return err
+	}
+	defer result.Body.Close()
+
+	return json.Unmarshal(body, to)
+}
+
+// ExtractRaw extracts ResponseResult body into the slice of bytes without unmarshalling.
+func (result *ResponseResult) ExtractRaw() ([]byte, error) {
+	bytes, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return nil, err
+	}
+	defer result.Body.Close()
+
+	return bytes, nil
+}
+
+// extractErr populates an error message and error structure in the ResponseResult body.
+func (result *ResponseResult) extractErr() error {
+	body, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return err
+	}
+	defer result.Body.Close()
+
+	if len(body) == 0 {
+		result.Err = fmt.Errorf("domains-go: got the %d status code from the server", result.StatusCode)
+		return nil
+	}
+
+	switch result.StatusCode {
+	case http.StatusNotFound:
+		err = json.Unmarshal(body, &result.ErrNotFound)
+	default:
+		err = json.Unmarshal(body, &result.ErrGeneric)
+	}
+	if err != nil {
+		result.Err = fmt.Errorf("domains-go: got invalid response from the server")
+		return nil
+	}
+
+	result.Err = fmt.Errorf("domains-go: got the %d status code from the server: %s",
+		result.StatusCode, string(body))
+
+	return nil
+}

--- a/vendor/github.com/selectel/domains-go/pkg/v1/client.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/client.go
@@ -16,10 +16,13 @@ const (
 	appName = "domains-go"
 
 	// appVersion is a version of the application.
-	appVersion = "0.1.0"
+	appVersion = "0.2.0"
 
 	// userAgent contains a basic user agent that will be used in queries.
 	userAgent = appName + "/" + appVersion
+
+	// defaultEndpoint represents default endpoint for Selectel Domains API v1.
+	defaultEndpoint = "https://api.selectel.ru/domains/v1"
 
 	// defaultHTTPTimeout represents the default timeout (in seconds) for HTTP requests.
 	defaultHTTPTimeout = 120
@@ -68,6 +71,17 @@ func NewDomainsClientV1(token, endpoint string) *ServiceClient {
 		HTTPClient: newHTTPClient(),
 		Token:      token,
 		Endpoint:   endpoint,
+		UserAgent:  userAgent,
+	}
+}
+
+// NewDomainsClientV1WithDefaultEndpoint initializes a new client for the Domains API V1
+// with default endpoint.
+func NewDomainsClientV1WithDefaultEndpoint(token string) *ServiceClient {
+	return &ServiceClient{
+		HTTPClient: newHTTPClient(),
+		Token:      token,
+		Endpoint:   defaultEndpoint,
 		UserAgent:  userAgent,
 	}
 }

--- a/vendor/github.com/selectel/domains-go/pkg/v1/doc.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/doc.go
@@ -1,0 +1,4 @@
+/*
+Package v1 provides a library to work with the Selectel Domains API V1.
+*/
+package v1

--- a/vendor/github.com/selectel/domains-go/pkg/v1/domain/doc.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/domain/doc.go
@@ -1,0 +1,49 @@
+/*
+Package domain provides the ability to interact with domains
+through the Selectel Domains API V1.
+
+Example of getting a single domain by its id
+
+  selectelDomain, _, err := domain.GetByID(ctx, serviceClient, domainID)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%+v\n", selectelDomain)
+
+Example of getting a single domain by its name
+
+  selectelDomain, _, err := domain.GetByName(ctx, serviceClient, domainName)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%+v\n", selectelDomain)
+
+Example of getting a list of domains
+
+  selectelDomains, _, err := domain.List(ctx, serviceClient)
+  if err != nil {
+    log.Fatal(err)
+  }
+  for _, d := range selectelDomains {
+    fmt.Printf("%+v\n", d)
+  }
+
+Example of creating a new domain
+
+  createOpts := &domain.CreateOpts{
+    Name:        "testdomain.xyz",
+  }
+  selectelDomain, _, err := domain.Create(ctx, serviceClient, createOpts)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%+v\n", selectelDomain)
+
+Example of domain deletion
+
+  _, err := domain.Delete(ctx, serviceClient, domainID)
+  if err != nil {
+    log.Fatal(err)
+  }
+*/
+package domain

--- a/vendor/github.com/selectel/domains-go/pkg/v1/domain/requests.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/domain/requests.go
@@ -1,0 +1,128 @@
+package domain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	v1 "github.com/selectel/domains-go/pkg/v1"
+)
+
+// GetByID returns a single domain by its id.
+func GetByID(ctx context.Context, client *v1.ServiceClient, domainID int) (*View, *v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, strconv.Itoa(domainID)}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a domain from the response body.
+	domain := &View{}
+	err = responseResult.ExtractResult(domain)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return domain, responseResult, nil
+}
+
+// GetByName returns a single domain by its domain name.
+func GetByName(ctx context.Context, client *v1.ServiceClient, domainName string) (*View, *v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, domainName}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a domain from the response body.
+	domain := &View{}
+	err = responseResult.ExtractResult(domain)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return domain, responseResult, nil
+}
+
+// List gets a list of all domains.
+func List(ctx context.Context, client *v1.ServiceClient) ([]*View, *v1.ResponseResult, error) {
+	url := client.Endpoint + "/"
+	responseResult, err := client.DoRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract domains from the response body.
+	var domains []*View
+	err = responseResult.ExtractResult(&domains)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return domains, responseResult, nil
+}
+
+// Create requests a creation of a new domain.
+func Create(ctx context.Context, client *v1.ServiceClient, opts *CreateOpts) (*View, *v1.ResponseResult, error) {
+	requestBody, err := json.Marshal(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	url := client.Endpoint + "/"
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	if opts.BindZone != "" {
+		result := struct {
+			Domain *View `json:"domain"`
+		}{}
+
+		// Extract domain from the response body.
+		err = responseResult.ExtractResult(&result)
+		if err != nil {
+			return nil, responseResult, err
+		}
+		return result.Domain, responseResult, nil
+	}
+
+	// Extract domain from the response body.
+	domain := &View{}
+	err = responseResult.ExtractResult(domain)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return domain, responseResult, nil
+}
+
+// Delete deletes a single domain by its id.
+func Delete(ctx context.Context, client *v1.ServiceClient, domainID int) (*v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, strconv.Itoa(domainID)}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/vendor/github.com/selectel/domains-go/pkg/v1/domain/requests_opts.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/domain/requests_opts.go
@@ -1,0 +1,10 @@
+package domain
+
+// CreateOpts represents requests options to create a domain.
+type CreateOpts struct {
+	// Name represents domain name.
+	Name string `json:"name,omitempty"`
+
+	// BindZone represents zone files in BIND format.
+	BindZone string `json:"bind_zone,omitempty"`
+}

--- a/vendor/github.com/selectel/domains-go/pkg/v1/domain/schemas.go
+++ b/vendor/github.com/selectel/domains-go/pkg/v1/domain/schemas.go
@@ -1,0 +1,22 @@
+package domain
+
+// View represents an unmarshalled domain body from API response.
+type View struct {
+	// ID is the identifier of the domain.
+	ID int `json:"id"`
+
+	// CreateDate represents Unix timestamp when domain has been created.
+	CreateDate int `json:"create_date"`
+
+	// ChangeDate represents Unix timestamp when domain has been modified.
+	ChangeDate int `json:"change_date"`
+
+	// UserID is the Selectel user's identifier.
+	UserID int `json:"user_id"`
+
+	// Name represents domain name.
+	Name string `json:"name"`
+
+	// Tags is the list of tags applied for the domain.
+	Tags []string `json:"tags"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
-# github.com/selectel/domains-go v0.1.0
+# github.com/selectel/domains-go v0.2.0
 ## explicit
 github.com/selectel/domains-go/pkg/v1
 github.com/selectel/domains-go/pkg/v1/domain

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,6 +214,10 @@ github.com/posener/complete
 github.com/posener/complete/cmd
 github.com/posener/complete/cmd/install
 github.com/posener/complete/match
+# github.com/selectel/domains-go v0.1.0
+## explicit
+github.com/selectel/domains-go/pkg/v1
+github.com/selectel/domains-go/pkg/v1/domain
 # github.com/selectel/go-selvpcclient v1.11.0
 ## explicit
 github.com/selectel/go-selvpcclient/selvpcclient

--- a/website/docs/r/domains_domain_v1.html.markdown
+++ b/website/docs/r/domains_domain_v1.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_domains_domain_v1"
+sidebar_current: "docs-selectel-resource-domains-domain-v1"
+description: |-
+  Manages a V1 domain resource within Selectel Domains API Service.
+---
+
+# selectel\_domains\_domain\_v1
+
+Manages a V1 domain resource within Selectel Domains API Service.
+
+## Example usage
+
+```hcl
+resource "selectel_domains_domain_v1" "domain_1" {
+  name = "test-domain.xyz"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the domain.
+  Changing this creates a new domain name.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of the domain.
+
+## Import
+
+Domain can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN terraform import selectel_domains_domain_v1.domain_1 45623
+```

--- a/website/docs/r/domains_domain_v1.html.markdown
+++ b/website/docs/r/domains_domain_v1.html.markdown
@@ -31,6 +31,12 @@ The following attributes are exported:
 
 * `name` - The name of the domain.
 
+* `create_date` - Unix-timestamp when domain has been created.
+
+* `change_date` - Unix-timestamp when domain has been updated.
+
+* `user_id` - Identifier of the Selectel API user.
+
 ## Import
 
 Domain can be imported using the `id`, e.g.

--- a/website/docs/r/domains_domain_v1.html.markdown
+++ b/website/docs/r/domains_domain_v1.html.markdown
@@ -31,10 +31,6 @@ The following attributes are exported:
 
 * `name` - The name of the domain.
 
-* `create_date` - Unix-timestamp when domain has been created.
-
-* `change_date` - Unix-timestamp when domain has been updated.
-
 * `user_id` - Identifier of the Selectel API user.
 
 ## Import

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -55,6 +55,15 @@
           </ul>
         </li>
 
+         <li<%= sidebar_current("docs-selectel-resource-domains") %>>
+           <a href="#">Domains Resources</a>
+           <ul class="nav nav-visible">
+             <li<%= sidebar_current("docs-selectel-resource-domains-domain-v1") %>>
+               <a href="/docs/providers/selectel/r/domains_domain_v1.html">selectel_domains_domain_v1</a>
+             </li>
+           </ul>
+         </li>
+
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
For #71 

This PR adds "selectel_domains_domain_v1" resource implementation, acc-tests and docs.
Vendor domains-go v0.2.0 dependency to work with Selectel Domains API.