### PR TITLE
MKS Nodegroup V1: add labels support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
 	github.com/selectel/go-selvpcclient v1.11.0
-	github.com/selectel/mks-go v0.2.0
+	github.com/selectel/mks-go v0.3.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/selectel/go-selvpcclient v1.11.0 h1:M3p6LpTHe3AnQlQ+qIup3XLclztFcX5cSsLDmopK+X8=
 github.com/selectel/go-selvpcclient v1.11.0/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
-github.com/selectel/mks-go v0.2.0 h1:DyAbcjM03bO6Jq7J7apX+engY4GVZP1RHMkSfrzHFnc=
-github.com/selectel/mks-go v0.2.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
+github.com/selectel/mks-go v0.3.0 h1:b/+QbDcWNNWXuzEFQaKMeU1f0fxFle1W68+/qj8/pnc=
+github.com/selectel/mks-go v0.3.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -373,3 +373,13 @@ func flattenMKSNodegroupV1Nodes(views []*node.View) []map[string]interface{} {
 
 	return nodes
 }
+
+func expandMKSNodegroupV1Labels(labels map[string]interface{}) map[string]string {
+	result := make(map[string]string)
+
+	for k, v := range labels {
+		result[k] = v.(string)
+	}
+
+	return result
+}

--- a/selectel/mks_test.go
+++ b/selectel/mks_test.go
@@ -380,3 +380,19 @@ func TestFlattenMKSNodegroupV1Nodes(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestExpandMKSNodegroupV1Labels(t *testing.T) {
+	labels := map[string]interface{}{
+		"label-key0": "label-value0",
+		"label-key1": "label-value1",
+		"label-key2": "label-value2",
+	}
+	expected := map[string]string{
+		"label-key0": "label-value0",
+		"label-key1": "label-value1",
+		"label-key2": "label-value2",
+	}
+	actual := expandMKSNodegroupV1Labels(labels)
+
+	assert.Equal(t, expected, actual)
+}

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -42,6 +42,9 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "ram_mb", "1024"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_gb", "10"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-3a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
 				),
 			},
 			{
@@ -54,6 +57,8 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "ram_mb", "1024"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_gb", "10"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-3a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 				),
 			},
 		},
@@ -135,6 +140,11 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   ram_mb            = 1024
   volume_gb         = 10
   volume_type       = "fast.ru-3a"
+  labels = {
+    label-key0 = "label-value0"
+    label-key1 = "label-value1"
+    label-key2 = "label-value2"
+  }
 }`, projectName, clusterName, kubeVersion)
 }
 
@@ -162,5 +172,9 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   ram_mb            = 1024
   volume_gb         = 10
   volume_type       = "fast.ru-3a"
+  labels = {
+    label-key3 = "label-value3"
+    label-key4 = "label-value4"
+  }
 }`, projectName, clusterName, kubeVersion)
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/client.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/client.go
@@ -57,6 +57,8 @@ const (
 	defaultExpectContinueTimeout = 1
 )
 
+const errGotHTTPStatusCodeFmt = "mks-go: got the %d status code from the server"
+
 // ServiceClient stores details that are needed to work with Selectel Managed Kubernetes Service API.
 type ServiceClient struct {
 	// HTTPClient represents an initialized HTTP client that will be used to do requests.
@@ -208,7 +210,7 @@ func (result *ResponseResult) extractErr() error {
 	defer result.Body.Close()
 
 	if len(body) == 0 {
-		result.Err = fmt.Errorf("mks-go: got the %d status code from the server", result.StatusCode)
+		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
 		return nil
 	}
 	if result.StatusCode == http.StatusNotFound {
@@ -217,10 +219,11 @@ func (result *ResponseResult) extractErr() error {
 		err = json.Unmarshal(body, &result.ErrGeneric)
 	}
 	if err != nil {
-		return err
+		result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt, result.StatusCode)
+		return nil
 	}
 
-	result.Err = fmt.Errorf("mks-go: got the %d status code from the server: %s", result.StatusCode, string(body))
+	result.Err = fmt.Errorf(errGotHTTPStatusCodeFmt+": %s", result.StatusCode, string(body))
 
 	return nil
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
@@ -35,6 +35,11 @@ Example of creating a new cluster
         VolumeType:       "fast.ru-3a",
         KeypairName:      "ssh-key",
         AvailabilityZone: "ru-3a",
+        Labels: map[string]string{
+          "label-key0": "label-value0",
+          "label-key1": "label-value1",
+          "label-key2": "label-value2",
+        },
       },
     },
   }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/schemas.go
@@ -18,6 +18,7 @@ const (
 	StatusPendingResize              Status = "PENDING_RESIZE"
 	StatusPendingNodeReinstall       Status = "PENDING_NODE_REINSTALL"
 	StatusPendingUpgradePatchVersion Status = "PENDING_UPGRADE_PATCH_VERSION"
+	StatusPendingUpdateNodegroup     Status = "PENDING_UPDATE_NODEGROUP"
 	StatusMaintenance                Status = "MAINTENANCE"
 	StatusError                      Status = "ERROR"
 	StatusUnknown                    Status = "UNKNOWN"
@@ -118,6 +119,8 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Status = StatusPendingNodeReinstall
 	case StatusPendingUpgradePatchVersion:
 		result.Status = StatusPendingUpgradePatchVersion
+	case StatusPendingUpdateNodegroup:
+		result.Status = StatusPendingUpdateNodegroup
 	case StatusMaintenance:
 		result.Status = StatusMaintenance
 	case StatusError:

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/doc.go
@@ -30,6 +30,11 @@ Example of creating a new cluster nodegroup
     VolumeType:       "fast.ru-3a",
     KeypairName:      "ssh-key",
     AvailabilityZone: "ru-3a",
+    Labels: map[string]string{
+      "label-key0": "label-value0",
+      "label-key1": "label-value1",
+      "label-key2": "label-value2",
+    },
   }
   _, err := nodegroup.Create(ctx, mksClient, clusterID, createOpts)
   if err != nil {
@@ -49,6 +54,20 @@ Example of resizing a single cluster nodegroup
     Desired: 1,
   }
   _, err := nodegroup.Resize(ctx, mksClient, clusterID, nodegroupID, resizeOpts)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+Example of updating nodegroup labels
+
+  updateOpts := &nodegroup.UpdateOpts{
+    Labels: map[string]string{
+      "label-key0": "label-value0",
+      "label-key1": "label-value1",
+      "label-key2": "label-value2",
+    },
+  }
+  _, err := nodegroup.Update(ctx, mksClient, clusterID, nodegroupID, updateOpts)
   if err != nil {
     log.Fatal(err)
   }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests.go
@@ -117,3 +117,27 @@ func Resize(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupI
 
 	return responseResult, err
 }
+
+// Update requests a update of a cluster nodegroup by its id.
+func Update(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID string, opts *UpdateOpts) (*v1.ResponseResult, error) {
+	updateNodegroupOpts := struct {
+		Nodegroup *UpdateOpts `json:"nodegroup"`
+	}{
+		Nodegroup: opts,
+	}
+	requestBody, err := json.Marshal(updateNodegroupOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodPut, url, bytes.NewReader(requestBody))
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
@@ -36,10 +36,21 @@ type CreateOpts struct {
 
 	// AvailabilityZone should contain the valid zone in the selected region of the created cluster.
 	AvailabilityZone string `json:"availability_zone,omitempty"`
+
+	// Labels represents an object containing a set of Kubernetes labels that will be applied
+	// for each node in the group. The keys must be user-defined.
+	Labels map[string]string `json:"labels"`
 }
 
 // ResizeOpts represents options for the nodegroup Resize request.
 type ResizeOpts struct {
 	// Desired represents desired amount of nodes for this nodegroup.
 	Desired int `json:"desired"`
+}
+
+// UpdateOpts represents options for the nodegroup Update request.
+type UpdateOpts struct {
+	// Labels represents an object containing a set of Kubernetes labels that will be applied
+	// for each node in the group. The keys must be user-defined.
+	Labels map[string]string `json:"labels"`
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
@@ -37,4 +37,8 @@ type View struct {
 
 	// Nodes contains list of all nodes in the nodegroup.
 	Nodes []*node.View `json:"nodes"`
+
+	// Labels represents an object containing a set of Kubernetes labels that will be applied
+	// for each node in the group. The keys must be user-defined.
+	Labels map[string]string `json:"labels"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -230,7 +230,7 @@ github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/subnets
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/users
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/vrrpsubnets
-# github.com/selectel/mks-go v0.2.0
+# github.com/selectel/mks-go v0.3.0
 ## explicit
 github.com/selectel/mks-go/pkg/v1
 github.com/selectel/mks-go/pkg/v1/cluster

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -34,6 +34,11 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
   ram_mb            = 2048
   volume_gb         = 20
   volume_type       = "fast.ru-3a"
+  labels            = {
+    "label-key0": "label-value0",
+    "label-key1": "label-value1",
+    "label-key2": "label-value2",
+  }
 }
 ```
 
@@ -82,6 +87,9 @@ The following arguments are supported:
 
 * `flavor_id` (Optional) An OpenStack flavor identifier for all nodes in the nodegroup. It can be omitted in most cases.
   Changing this creates a new nodegroup.
+
+* `labels` (Optional) Represents a map containing a set of Kubernetes labels that will be applied
+  for each node in the group. The keys must be user-defined.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add nodegroup labels support for "selectel_mks_nodegroup_v1" resource.
Update acc-tests with doc.
Vendor mks-go v0.3.0.

For #87 