### PR TITLE
MKS Nodegroup V1: fix resource import

### DIFF
--- a/selectel/import_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/import_selectel_mks_nodegroup_v1_test.go
@@ -26,7 +26,7 @@ func TestAccMKSNodegroupV1ImportBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"nodes_count", "cpus", "ram_mb"},
+				ImportStateVerifyIgnore: []string{"cpus", "ram_mb"},
 			},
 		},
 	})

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -261,6 +261,7 @@ func resourceMKSNodegroupV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("volume_type", mksNodegroup.VolumeType)
 	d.Set("local_volume", mksNodegroup.LocalVolume)
 	d.Set("availability_zone", mksNodegroup.AvailabilityZone)
+	d.Set("nodes_count", len(mksNodegroup.Nodes))
 
 	if err := d.Set("labels", mksNodegroup.Labels); err != nil {
 		log.Print(errSettingComplexAttr("labels", err))


### PR DESCRIPTION
Update "resourceMKSNodegroupV1Read" method to import nodegroup properly.
Update "TestAccMKSNodegroupV1ImportBasic".

For #89