### PR TITLE
MKS Cluster V1: add minor version upgrade support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.10.0
 	github.com/selectel/domains-go v0.2.0
 	github.com/selectel/go-selvpcclient v1.11.0
-	github.com/selectel/mks-go v0.3.0
+	github.com/selectel/mks-go v0.4.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -177,14 +177,13 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/selectel/domains-go v0.1.0 h1:Je7Q5YfTevGsyRiVMBcXqXJZnffN24JZVAZRPnhK4nk=
-github.com/selectel/domains-go v0.1.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
 github.com/selectel/domains-go v0.2.0 h1:UBm6tc45sXsziqG7MirfHxaoMf3yYpFb2vx3GygU4kI=
 github.com/selectel/domains-go v0.2.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
 github.com/selectel/go-selvpcclient v1.11.0 h1:M3p6LpTHe3AnQlQ+qIup3XLclztFcX5cSsLDmopK+X8=
 github.com/selectel/go-selvpcclient v1.11.0/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
-github.com/selectel/mks-go v0.3.0 h1:b/+QbDcWNNWXuzEFQaKMeU1f0fxFle1W68+/qj8/pnc=
-github.com/selectel/mks-go v0.3.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
+github.com/selectel/mks-go v0.4.0 h1:zHY+eG+k8S8Jrfv8/nLUFDQSLR93usnhTcorsS54FTU=
+github.com/selectel/mks-go v0.4.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -305,6 +304,7 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -232,47 +232,12 @@ func upgradeMKSClusterV1KubeVersion(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-// kubeVersionTrimToMinor returns given Kubernetes version trimmed to minor.
-func kubeVersionTrimToMinor(kubeVersion string) (string, error) {
-	// Trim version prefix if needed.
-	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
-
-	kubeVersionParts := strings.Split(kubeVersion, ".")
-	if len(kubeVersionParts) < 2 {
-		return "", errKubeVersionIsInvalidFmt(kubeVersion, "expected to have major and minor version parts")
-	}
-
-	majorPart := kubeVersionParts[0]
-	major, err := strconv.Atoi(majorPart)
-	if err != nil {
-		return "", errKubeVersionIsInvalidFmt(kubeVersion, "major part is not an integer number")
-	}
-	if major < 0 {
-		return "", errKubeVersionIsInvalidFmt(kubeVersion, "major part is a negative number")
-	}
-
-	minorPart := kubeVersionParts[1]
-	minor, err := strconv.Atoi(minorPart)
-	if err != nil {
-		return "", errKubeVersionIsInvalidFmt(kubeVersion, "minor part is not an integer number")
-	}
-	if minor < 0 {
-		return "", errKubeVersionIsInvalidFmt(kubeVersion, "minor part is a negative number")
-	}
-
-	return strings.Join([]string{majorPart, minorPart}, "."), nil
-}
-
 // kubeVersionToMajor returns given Kubernetes version major part.
 func kubeVersionToMajor(kubeVersion string) (int, error) {
 	// Trim version prefix if needed.
 	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
 
 	kubeVersionParts := strings.Split(kubeVersion, ".")
-	if len(kubeVersionParts) < 3 {
-		return 0, errKubeVersionIsInvalidFmt(kubeVersion, "expected to have major, minor and patch version parts")
-	}
-
 	majorPart := kubeVersionParts[0]
 	major, err := strconv.Atoi(majorPart)
 	if err != nil {
@@ -291,8 +256,8 @@ func kubeVersionToMinor(kubeVersion string) (int, error) {
 	kubeVersion = strings.TrimPrefix(kubeVersion, "v")
 
 	kubeVersionParts := strings.Split(kubeVersion, ".")
-	if len(kubeVersionParts) < 3 {
-		return 0, errKubeVersionIsInvalidFmt(kubeVersion, "expected to have major, minor and patch version parts")
+	if len(kubeVersionParts) < 2 {
+		return 0, errKubeVersionIsInvalidFmt(kubeVersion, "expected to have major and minor version parts")
 	}
 
 	minorPart := kubeVersionParts[1]
@@ -348,6 +313,39 @@ func compareTwoKubeVersionsByPatch(a, b string) (string, error) {
 	}
 
 	return b, nil
+}
+
+// kubeVersionTrimToMinor returns given Kubernetes version trimmed to minor.
+func kubeVersionTrimToMinor(kubeVersion string) (string, error) {
+	major, err := kubeVersionToMajor(kubeVersion)
+	if err != nil {
+		return "", err
+	}
+
+	minor, err := kubeVersionToMinor(kubeVersion)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Join([]string{strconv.Itoa(major), strconv.Itoa(minor)}, "."), nil
+}
+
+// KubeVersionTrimToMinorIncremented returns given Kubernetes version trimmed to minor incremented by 1.
+func kubeVersionTrimToMinorIncremented(kubeVersion string) (string, error) {
+	major, err := kubeVersionToMajor(kubeVersion)
+	if err != nil {
+		return "", err
+	}
+
+	minor, err := kubeVersionToMinor(kubeVersion)
+	if err != nil {
+		return "", err
+	}
+
+	// Increment minor version.
+	minor++
+
+	return strings.Join([]string{strconv.Itoa(major), strconv.Itoa(minor)}, "."), nil
 }
 
 func mksNodegroupV1ParseID(id string) (string, string, error) {

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -217,7 +217,7 @@ func upgradeMKSClusterV1KubeVersion(ctx context.Context, d *schema.ResourceData,
 			currentVersion, desiredVersion, latestVersion)
 	}
 
-	_, err = cluster.UpgradePatchVersion(ctx, client, d.Id())
+	_, _, err = cluster.UpgradePatchVersion(ctx, client, d.Id())
 	if err != nil {
 		return fmt.Errorf("error upgrading patch version: %s", err)
 	}

--- a/selectel/mks_test.go
+++ b/selectel/mks_test.go
@@ -22,77 +22,6 @@ func TestGetMKSClusterV1Endpoint(t *testing.T) {
 	}
 }
 
-func TestKubeVersionTrimToMinorValid(t *testing.T) {
-	tableTests := []struct {
-		kubeVersion,
-		expected string
-	}{
-		{
-			kubeVersion: "v1.15.3",
-			expected:    "1.15",
-		},
-		{
-			kubeVersion: "v1.16.0",
-			expected:    "1.16",
-		},
-		{
-			kubeVersion: "1.15.2",
-			expected:    "1.15",
-		},
-		{
-			kubeVersion: "v2.0.0-alpha",
-			expected:    "2.0",
-		},
-		{
-			kubeVersion: "1.15",
-			expected:    "1.15",
-		},
-		{
-			kubeVersion: "v1.17.18.19.20",
-			expected:    "1.17",
-		},
-		{
-			kubeVersion: "2.21.22.23.24",
-			expected:    "2.21",
-		},
-	}
-
-	for _, test := range tableTests {
-		actual, err := kubeVersionTrimToMinor(test.kubeVersion)
-		if err != nil {
-			t.Error(err)
-		}
-		if actual != test.expected {
-			t.Errorf("Expected %s kube version, but got: %s", test.expected, actual)
-		}
-	}
-}
-
-func TestKubeVersionTrimToMinorInvalid(t *testing.T) {
-	tableTests := []string{
-		"",
-		"va.12.3",
-		"v1.a.3",
-		"v1.a",
-		"abc",
-		"abc.def",
-		"-1.12.13",
-		"1.-12",
-		"v-1.15",
-		"v1.-20.3",
-	}
-
-	for _, kubeVersion := range tableTests {
-		actual, err := kubeVersionTrimToMinor(kubeVersion)
-		if err == nil {
-			t.Error("Expected kube version parsing error but got nil")
-		}
-		if actual != "" {
-			t.Errorf("Expected empty kube version, but got: %s", actual)
-		}
-	}
-}
-
 func TestKubeVersionToMajorValid(t *testing.T) {
 	tableTests := []struct {
 		kubeVersion string
@@ -103,16 +32,24 @@ func TestKubeVersionToMajorValid(t *testing.T) {
 			expected:    1,
 		},
 		{
-			kubeVersion: "v1.16.0",
+			kubeVersion: "v1.16",
 			expected:    1,
 		},
 		{
-			kubeVersion: "1.15.2",
+			kubeVersion: "v1",
 			expected:    1,
 		},
 		{
-			kubeVersion: "2.21.22",
+			kubeVersion: "2",
 			expected:    2,
+		},
+		{
+			kubeVersion: "v1.abc",
+			expected:    1,
+		},
+		{
+			kubeVersion: "1.-25",
+			expected:    1,
 		},
 	}
 
@@ -131,11 +68,11 @@ func TestKubeVersionToMajorInvalid(t *testing.T) {
 	tableTests := []string{
 		"",
 		"v.12.a3",
-		"v1.a",
 		"abc",
 		"abc.def",
 		"-1.12.13",
 		"-v.15.1",
+		"-1",
 	}
 
 	for _, kubeVersion := range tableTests {
@@ -163,11 +100,19 @@ func TestKubeVersionToMinorValid(t *testing.T) {
 			expected:    16,
 		},
 		{
-			kubeVersion: "1.15.2",
+			kubeVersion: "1.15",
 			expected:    15,
 		},
 		{
-			kubeVersion: "2.21.22",
+			kubeVersion: "2.21.22.20",
+			expected:    21,
+		},
+		{
+			kubeVersion: "a.21",
+			expected:    21,
+		},
+		{
+			kubeVersion: "-2.21",
 			expected:    21,
 		},
 	}
@@ -261,7 +206,7 @@ func TestKubeVersionToPatchInvalid(t *testing.T) {
 	}
 }
 
-func TestGetLatestKubeVersionPatchVersionValid(t *testing.T) {
+func TestCompareTwoKubeVersionsByPatchValid(t *testing.T) {
 	tableTests := []struct {
 		a, b, result string
 	}{
@@ -293,7 +238,7 @@ func TestGetLatestKubeVersionPatchVersionValid(t *testing.T) {
 	}
 }
 
-func TestGetLatestKubeVersionPatchVersionInvalid(t *testing.T) {
+func TestCompareTwoKubeVersionsByPatchInvalid(t *testing.T) {
 	tableTests := []struct {
 		a, b, result string
 	}{
@@ -318,6 +263,123 @@ func TestGetLatestKubeVersionPatchVersionInvalid(t *testing.T) {
 		}
 		if actual != "" {
 			t.Errorf("Expected empty kube version, but got: %s", actual)
+		}
+	}
+}
+
+func TestKubeVersionTrimToMinorValid(t *testing.T) {
+	tableTests := []struct {
+		kubeVersion,
+		expected string
+	}{
+		{
+			kubeVersion: "v1.15.3",
+			expected:    "1.15",
+		},
+		{
+			kubeVersion: "v1.16.0",
+			expected:    "1.16",
+		},
+		{
+			kubeVersion: "1.15.2",
+			expected:    "1.15",
+		},
+		{
+			kubeVersion: "v2.0.0-alpha",
+			expected:    "2.0",
+		},
+		{
+			kubeVersion: "1.15",
+			expected:    "1.15",
+		},
+		{
+			kubeVersion: "v1.17.18.19.20",
+			expected:    "1.17",
+		},
+		{
+			kubeVersion: "2.21.22.23.24",
+			expected:    "2.21",
+		},
+	}
+
+	for _, test := range tableTests {
+		actual, err := kubeVersionTrimToMinor(test.kubeVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		if actual != test.expected {
+			t.Errorf("Expected %s kube version, but got: %s", test.expected, actual)
+		}
+	}
+}
+
+func TestKubeVersionTrimToMinorInvalid(t *testing.T) {
+	tableTests := []string{
+		"",
+		"va.12.3",
+		"v1.a.3",
+		"v1.a",
+		"abc",
+		"abc.def",
+		"-1.12.13",
+		"1.-12",
+		"v-1.15",
+		"v1.-20.3",
+	}
+
+	for _, kubeVersion := range tableTests {
+		actual, err := kubeVersionTrimToMinor(kubeVersion)
+		if err == nil {
+			t.Error("Expected kube version parsing error but got nil")
+		}
+		if actual != "" {
+			t.Errorf("Expected empty kube version, but got: %s", actual)
+		}
+	}
+}
+
+func TestKubeVersionTrimToMinorIncrementedValid(t *testing.T) {
+	tableTests := []struct {
+		kubeVersion,
+		expected string
+	}{
+		{
+			kubeVersion: "v1.15.3",
+			expected:    "1.16",
+		},
+		{
+			kubeVersion: "v1.16.0",
+			expected:    "1.17",
+		},
+		{
+			kubeVersion: "1.15.2",
+			expected:    "1.16",
+		},
+		{
+			kubeVersion: "v2.0.0-alpha",
+			expected:    "2.1",
+		},
+		{
+			kubeVersion: "1.18",
+			expected:    "1.19",
+		},
+		{
+			kubeVersion: "v1.17.18.19.20",
+			expected:    "1.18",
+		},
+		{
+			kubeVersion: "2.21.22.23.24",
+			expected:    "2.22",
+		},
+	}
+
+	for _, test := range tableTests {
+		actual, err := kubeVersionTrimToMinorIncremented(test.kubeVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		if actual != test.expected {
+			t.Errorf("Expected %s kube version, but got: %s", test.expected, actual)
 		}
 	}
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/client.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/client.go
@@ -17,6 +17,7 @@ const (
 	ResourceURLKubeconfig          = "kubeconfig"
 	ResourceURLRotateCerts         = "rotate-certs"
 	ResourceURLUpgradePatchVersion = "upgrade-patch-version"
+	ResourceURLUpgradeMinorVersion = "upgrade-minor-version"
 	ResourceURLTask                = "tasks"
 	ResourceURLNodegroup           = "nodegroups"
 	ResourceURLResize              = "resize"

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
@@ -84,9 +84,18 @@ Example of rotating certificates by cluster id
 
 Example of upgrading Kubernetes patch version by cluster id
 
-  _, err := cluster.UpgradePatchVersion(ctx, mksClient, clusterID)
+  mksCluster, _, err := cluster.UpgradePatchVersion(ctx, mksClient, clusterID)
   if err != nil {
     log.Fatal(err)
   }
+  fmt.Printf("%+v\n", mksCluster)
+
+Example of upgrading Kubernetes minor version by cluster id
+
+  mksCluster, _, err := cluster.UpgradeMinorVersion(ctx, mksClient, clusterID)
+  if err != nil {
+    log.Fatal(err)
+  }
+  fmt.Printf("%+v\n", mksCluster)
 */
 package cluster

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/requests.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/requests.go
@@ -171,15 +171,47 @@ func RotateCerts(ctx context.Context, client *v1.ServiceClient, clusterID string
 }
 
 // UpgradePatchVersion requests a Kubernetes patch version upgrade by cluster id.
-func UpgradePatchVersion(ctx context.Context, client *v1.ServiceClient, clusterID string) (*v1.ResponseResult, error) {
+func UpgradePatchVersion(ctx context.Context, client *v1.ServiceClient, clusterID string) (*View, *v1.ResponseResult, error) {
 	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLUpgradePatchVersion}, "/")
 	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if responseResult.Err != nil {
-		err = responseResult.Err
+		return nil, responseResult, responseResult.Err
 	}
 
-	return responseResult, err
+	// Extract a cluster from the response body.
+	var result struct {
+		Cluster *View `json:"cluster"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.Cluster, responseResult, nil
+}
+
+// UpgradeMinorVersion requests a Kubernetes minor version upgrade by cluster id.
+func UpgradeMinorVersion(ctx context.Context, client *v1.ServiceClient, clusterID string) (*View, *v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLUpgradeMinorVersion}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if responseResult.Err != nil {
+		return nil, responseResult, responseResult.Err
+	}
+
+	// Extract a cluster from the response body.
+	var result struct {
+		Cluster *View `json:"cluster"`
+	}
+	err = responseResult.ExtractResult(&result)
+	if err != nil {
+		return nil, responseResult, err
+	}
+
+	return result.Cluster, responseResult, nil
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/schemas.go
@@ -9,19 +9,21 @@ import (
 type Status string
 
 const (
-	StatusActive                     Status = "ACTIVE"
-	StatusPendingCreate              Status = "PENDING_CREATE"
-	StatusPendingUpdate              Status = "PENDING_UPDATE"
-	StatusPendingUpgrade             Status = "PENDING_UPGRADE"
-	StatusPendingRotateCerts         Status = "PENDING_ROTATE_CERTS"
-	StatusPendingDelete              Status = "PENDING_DELETE"
-	StatusPendingResize              Status = "PENDING_RESIZE"
-	StatusPendingNodeReinstall       Status = "PENDING_NODE_REINSTALL"
-	StatusPendingUpgradePatchVersion Status = "PENDING_UPGRADE_PATCH_VERSION"
-	StatusPendingUpdateNodegroup     Status = "PENDING_UPDATE_NODEGROUP"
-	StatusMaintenance                Status = "MAINTENANCE"
-	StatusError                      Status = "ERROR"
-	StatusUnknown                    Status = "UNKNOWN"
+	StatusActive                             Status = "ACTIVE"
+	StatusPendingCreate                      Status = "PENDING_CREATE"
+	StatusPendingUpdate                      Status = "PENDING_UPDATE"
+	StatusPendingUpgrade                     Status = "PENDING_UPGRADE"
+	StatusPendingRotateCerts                 Status = "PENDING_ROTATE_CERTS"
+	StatusPendingDelete                      Status = "PENDING_DELETE"
+	StatusPendingResize                      Status = "PENDING_RESIZE"
+	StatusPendingNodeReinstall               Status = "PENDING_NODE_REINSTALL"
+	StatusPendingUpgradePatchVersion         Status = "PENDING_UPGRADE_PATCH_VERSION"
+	StatusPendingUpgradeMinorVersion         Status = "PENDING_UPGRADE_MINOR_VERSION"
+	StatusPendingUpdateNodegroup             Status = "PENDING_UPDATE_NODEGROUP"
+	StatusPendingUpgradeMastersConfiguration Status = "PENDING_UPGRADE_MASTERS_CONFIGURATION"
+	StatusMaintenance                        Status = "MAINTENANCE"
+	StatusError                              Status = "ERROR"
+	StatusUnknown                            Status = "UNKNOWN"
 )
 
 // View represents an unmarshalled cluster body from an API response.
@@ -119,8 +121,12 @@ func (result *View) UnmarshalJSON(b []byte) error {
 		result.Status = StatusPendingNodeReinstall
 	case StatusPendingUpgradePatchVersion:
 		result.Status = StatusPendingUpgradePatchVersion
+	case StatusPendingUpgradeMinorVersion:
+		result.Status = StatusPendingUpgradeMinorVersion
 	case StatusPendingUpdateNodegroup:
 		result.Status = StatusPendingUpdateNodegroup
+	case StatusPendingUpgradeMastersConfiguration:
+		result.Status = StatusPendingUpgradeMastersConfiguration
 	case StatusMaintenance:
 		result.Status = StatusMaintenance
 	case StatusError:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/subnets
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/users
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/vrrpsubnets
-# github.com/selectel/mks-go v0.3.0
+# github.com/selectel/mks-go v0.4.0
 ## explicit
 github.com/selectel/mks-go/pkg/v1
 github.com/selectel/mks-go/pkg/v1/cluster

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -39,7 +39,11 @@ The following arguments are supported:
   Changing this creates a new cluster.
 
 * `kube_version` - (Required) The current Kubernetes version of the cluster.
-  Changing this upgrades the patch version of the cluster.
+  Changing this upgrades the current version of the cluster.
+  To upgrade a patch version, the desired version should match the latest available patch version for
+  the current minor release.
+  To upgrade a minor version, the desired version should match the next available minor release with
+  the latest patch version.
 
 * `enable_autorepair` - (Optional) Reflects if worker nodes are allowed to be reinstalled automatically.
   Accepts true or false. Defaults to true.


### PR DESCRIPTION
Add support for Kubernetes minor version upgrade in `selectel_mks_cluster_v1` resource.
Update kube version helper functions with tests.
Update website documentation.
Vendor mks-go v0.4.0 dependency.

For #92 