### PR TITLE
VPC Keypair V2: fix Read method

### DIFF
--- a/selectel/resource_selectel_vpc_keypair_v2.go
+++ b/selectel/resource_selectel_vpc_keypair_v2.go
@@ -98,7 +98,6 @@ func resourceVPCKeypairV2Read(d *schema.ResourceData, meta interface{}) error {
 			found = true
 			d.Set("name", keypair.Name)
 			d.Set("public_key", keypair.PublicKey)
-			d.Set("regions", keypair.Regions)
 			d.Set("user_id", keypair.UserID)
 		}
 	}


### PR DESCRIPTION
Don't set "regions" in resourceVPCKeypairV2Read method to avoid
resource replacement in case of an empty value in the config.

For #102 