### PR TITLE
VPC Keypair V2: fix import test

### DIFF
--- a/selectel/import_selectel_vpc_keypair_v2_test.go
+++ b/selectel/import_selectel_vpc_keypair_v2_test.go
@@ -23,9 +23,10 @@ func TestAccVPCV2KeypairImportBasic(t *testing.T) {
 				Config: testAccVPCV2KeypairBasic(userName, userPassword, keypairName, publicKey),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"regions"},
 			},
 		},
 	})


### PR DESCRIPTION
Update "TestAccVPCV2KeypairImportBasic".

For #105 