### PR TITLE
VPC Project: fix empty regions and zones in quotas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
 	github.com/selectel/domains-go v0.2.0
-	github.com/selectel/go-selvpcclient v1.11.0
+	github.com/selectel/go-selvpcclient v1.11.1
 	github.com/selectel/mks-go v0.4.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/selectel/domains-go v0.2.0 h1:UBm6tc45sXsziqG7MirfHxaoMf3yYpFb2vx3GygU4kI=
 github.com/selectel/domains-go v0.2.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
-github.com/selectel/go-selvpcclient v1.11.0 h1:M3p6LpTHe3AnQlQ+qIup3XLclztFcX5cSsLDmopK+X8=
-github.com/selectel/go-selvpcclient v1.11.0/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
+github.com/selectel/go-selvpcclient v1.11.1 h1:SdYEmM0sCR/m/CijwgTJvNgapSnWZ7PGlGaEJm5zyQQ=
+github.com/selectel/go-selvpcclient v1.11.1/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
 github.com/selectel/mks-go v0.4.0 h1:zHY+eG+k8S8Jrfv8/nLUFDQSLR93usnhTcorsS54FTU=
 github.com/selectel/mks-go v0.4.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/selectel/resource_selectel_vpc_project_v2.go
+++ b/selectel/resource_selectel_vpc_project_v2.go
@@ -327,8 +327,11 @@ func resourceVPCProjectV2QuotasOptsFromSet(quotaSet *schema.Set) ([]quotas.Quota
 		// Populate every quotas.ResourceQuotaOpts with data from a single
 		// resourceQuotasMap's region zone and value.
 		for j, resourceQuotasEntityRaw := range resourceQuotasEntities.List() {
-			var resourceQuotasEntityRegion, resourceQuotasEntityZone string
-			var resourceQuotasEntityValue int
+			var (
+				resourceQuotasEntityRegion string
+				resourceQuotasEntityZone   string
+				resourceQuotasEntityValue  int
+			)
 			resourceQuotasEntity := resourceQuotasEntityRaw.(map[string]interface{})
 			if region, ok := resourceQuotasEntity["region"]; ok {
 				resourceQuotasEntityRegion = region.(string)
@@ -342,8 +345,8 @@ func resourceVPCProjectV2QuotasOptsFromSet(quotaSet *schema.Set) ([]quotas.Quota
 			// Populate single entity of billing resource data with the region,
 			// zone and value information.
 			resourceQuotasOpts[j] = quotas.ResourceQuotaOpts{
-				Region: resourceQuotasEntityRegion,
-				Zone:   resourceQuotasEntityZone,
+				Region: &resourceQuotasEntityRegion,
+				Zone:   &resourceQuotasEntityZone,
 				Value:  &resourceQuotasEntityValue,
 			}
 		}

--- a/selectel/resource_selectel_vpc_project_v2_test.go
+++ b/selectel/resource_selectel_vpc_project_v2_test.go
@@ -212,6 +212,9 @@ resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
 }
 
 func TestResourceVPCProjectV2QuotasOptsFromSet(t *testing.T) {
+	region := "ru-3"
+	zone := "ru-3a"
+
 	quotaSet := &schema.Set{
 		F: quotasHashSetFunc(),
 	}
@@ -219,8 +222,8 @@ func TestResourceVPCProjectV2QuotasOptsFromSet(t *testing.T) {
 		F: resourceQuotasHashSetFunc(),
 	}
 	resourceQuotas.Add(map[string]interface{}{
-		"region": "ru-3",
-		"zone":   "ru-3a",
+		"region": region,
+		"zone":   zone,
 		"value":  100,
 	})
 	quotaSet.Add(map[string]interface{}{
@@ -234,8 +237,8 @@ func TestResourceVPCProjectV2QuotasOptsFromSet(t *testing.T) {
 			Name: "volume_gigabytes_fast",
 			ResourceQuotasOpts: []quotas.ResourceQuotaOpts{
 				{
-					Region: "ru-3",
-					Zone:   "ru-3a",
+					Region: &region,
+					Zone:   &zone,
 					Value:  &expectedResourceQuotaValue,
 				},
 			},

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/requests_opts.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/requests_opts.go
@@ -19,10 +19,10 @@ type QuotaOpts struct {
 // in the specific region and zone.
 type ResourceQuotaOpts struct {
 	// Region contains the quota region data.
-	Region string `json:"region,omitempty"`
+	Region *string `json:"region"`
 
 	// Zone contains the quota zone data.
-	Zone string `json:"zone,omitempty"`
+	Zone *string `json:"zone"`
 
 	// Value contans value of resource quota in the specific region and zone.
 	Value *int `json:"value"`

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// AppVersion is a version of the application.
-	AppVersion = "1.11.0"
+	AppVersion = "1.11.1"
 
 	// AppName is a global application name.
 	AppName = "go-selvpcclient"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/posener/complete/match
 github.com/selectel/domains-go/pkg/v1
 github.com/selectel/domains-go/pkg/v1/domain
 github.com/selectel/domains-go/pkg/v1/record
-# github.com/selectel/go-selvpcclient v1.11.0
+# github.com/selectel/go-selvpcclient v1.11.1
 ## explicit
 github.com/selectel/go-selvpcclient/selvpcclient
 github.com/selectel/go-selvpcclient/selvpcclient/resell


### PR DESCRIPTION
Vendor go-selvpcclient v1.11.1 that uses nullable strings for regions
and zones in quota options.

Update resourceVPCProjectV2QuotasOptsFromSet to use new types.

For #108 