### PR TITLE
VPC Project: fix empty regions and zones in quotas

### DIFF
--- a/selectel/resource_selectel_vpc_project_v2.go
+++ b/selectel/resource_selectel_vpc_project_v2.go
@@ -344,11 +344,13 @@ func resourceVPCProjectV2QuotasOptsFromSet(quotaSet *schema.Set) ([]quotas.Quota
 			}
 			// Populate single entity of billing resource data with the region,
 			// zone and value information.
-			resourceQuotasOpts[j] = quotas.ResourceQuotaOpts{
-				Region: &resourceQuotasEntityRegion,
-				Zone:   &resourceQuotasEntityZone,
-				Value:  &resourceQuotasEntityValue,
+			if resourceQuotasEntityRegion != "" {
+				resourceQuotasOpts[j].Region = &resourceQuotasEntityRegion
 			}
+			if resourceQuotasEntityZone != "" {
+				resourceQuotasOpts[j].Zone = &resourceQuotasEntityZone
+			}
+			resourceQuotasOpts[j].Value = &resourceQuotasEntityValue
 		}
 
 		// Populate single quota options element.


### PR DESCRIPTION
Fix resourceVPCProjectV2QuotasOptsFromSet to ignore empty strings
of zones and regions.

For #110 